### PR TITLE
ABCN-4668: Make cache_url_opts predictable

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,7 @@ requires 'English';
 requires 'File::Basename';
 requires 'File::Path';
 requires 'File::Spec';
-requires 'List::Util' => '1.30';
+requires 'List::Util' => '1.42';
 requires 'Mojolicious' => '5.82';
 requires 'POSIX';
 requires 'Readonly';

--- a/lib/Startsiden/UserAgent.pm
+++ b/lib/Startsiden/UserAgent.pm
@@ -10,7 +10,7 @@ use English qw(-no_match_vars);
 use File::Basename;
 use File::Path;
 use File::Spec;
-use List::Util;
+use List::Util 1.42;
 use Mojo::Transaction::HTTP;
 use Mojo::URL;
 use Mojo::Log;
@@ -227,7 +227,12 @@ sub _post_process_get {
 
 sub _cache_url_opts {
     my ($self, $url) = @_;
-    my ($pat, $opts) = List::Util::pairfirst { $url =~ /$a/; } %{ $self->cache_url_opts || {} };
+    my ($pat, $opts) =
+        List::Util::pairfirst { $url =~ /$a/ }
+        List::Util::unpairs
+        sort { length $b->key <=> length $a->key }
+        List::Util::pairs %{ $self->cache_url_opts || {} };
+
     return $opts || ();
 }
 
@@ -529,11 +534,11 @@ You may also set the C<SUA_NOCACHE> environment variable to avoid caching at all
 =head2 cache_url_opts
 
    my $urls_href = $ua->cache_url_opts;
-   $ua->cache_url_opts({ 
+   $ua->cache_url_opts({
        'https?://foo.com/long-lasting-data.*' => { expires_in => '2 weeks' }, # Cache some data two weeks
        '.*' => { expires_at => 0 }, # Don't store anything in cache
    });
-   
+
 Accepts a hash ref of regexp strings and expire times, this allows you to define cache validity time for individual URLs, hosts etc.
 The first match will be used.
 


### PR DESCRIPTION
We need to have some sort of sorting in the _cache_url_opts method, since more
than one url pattern can match. For now we trust longer patterns over shorter
patterns. If we don't sort, we trust hash order, which is random in newer
perls. We could consider adding another key in the options for weight, but lets
not complicate if we don't have to. sorting
